### PR TITLE
Fixes and Features

### DIFF
--- a/KDCalendar/CalendarView/CalendarHeaderView.swift
+++ b/KDCalendar/CalendarView/CalendarHeaderView.swift
@@ -30,7 +30,7 @@ open class CalendarHeaderView: UIView {
     lazy var monthLabel : UILabel = {
         let lbl = UILabel()
         lbl.textAlignment = NSTextAlignment.center
-        lbl.font = UIFont(name: CalendarView.Style.headerFontName, size: 20.0)
+        lbl.font = UIFont(name: CalendarView.Style.headerFontName, size: CalendarView.Style.headerFontSize)
         lbl.textColor = CalendarView.Style.headerTextColor
         
         self.addSubview(lbl)

--- a/KDCalendar/CalendarView/CalendarHeaderView.swift
+++ b/KDCalendar/CalendarView/CalendarHeaderView.swift
@@ -71,7 +71,7 @@ open class CalendarHeaderView: UIView {
         
         var frm = self.bounds
         frm.origin.y += 5.0
-        frm.size.height = 40.0
+        frm.size.height = self.bounds.size.height / 2.0 - 5.0
         
         self.monthLabel.frame = frm
         

--- a/KDCalendar/CalendarView/CalendarView+Style.swift
+++ b/KDCalendar/CalendarView/CalendarView+Style.swift
@@ -38,7 +38,8 @@ extension CalendarView {
         public static var headerHeight: CGFloat = 80.0
         public static var headerTextColor = UIColor.gray
         public static var headerFontName: String = "Helvetica"
-        
+        public static var headerFontSize: CGFloat = 20.0
+
         //Common
         public static var cellShape                 = CellShapeOptions.bevel(4.0)
         

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -321,7 +321,7 @@ extension CalendarView {
      */
     public func setDisplayDate(_ date : Date, animated: Bool = false) {
         
-        guard (date > startDateCache) && (date < endDateCache) else { return }
+        guard (date >= startDateCache) && (date <= endDateCache) else { return }
         self.collectionView.setContentOffset(self.scrollViewOffset(for: date), animated: animated)
         self.displayDateOnHeader(date)
     }

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -36,6 +36,12 @@ public struct CalendarEvent {
     let title: String
     let startDate: Date
     let endDate:Date
+    
+    public init(title: String, startDate: Date, endDate: Date) {
+        self.title = title;
+        self.startDate = startDate;
+        self.endDate = endDate;
+    }
 }
 
 public protocol CalendarViewDataSource {
@@ -95,7 +101,7 @@ public class CalendarView: UIView {
     internal var monthInfoForSection = [Int:(firstDay: Int, daysTotal: Int)]()
     internal var eventsByIndexPath = [IndexPath: [CalendarEvent]]()
     
-    var events: [CalendarEvent] = [] {
+    public var events: [CalendarEvent] = [] {
         didSet {
             self.eventsByIndexPath.removeAll()
             


### PR DESCRIPTION
1. In orde to manually add events to the calendarView.events it's necessary to make some components public
2. The boundary check on a valid date did not include the boundary. So if you would set 01 July 2018 to 31 October 2018 as range, 01 July 2018 and 30 October 2018 would NOT be valid dates. This is very odd
3. The height of the header can be set with a variable, but the height calculation was not done correctly. It was still assuming a height of 80
4. Added a variable for the Header Font Size, because I liked it a bit smaller ;-)