### PR TITLE
added 'public' to loadEvents and title,startDate,endDate

### DIFF
--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -33,9 +33,9 @@ struct EventLocation {
 }
 
 public struct CalendarEvent {
-    let title: String
-    let startDate: Date
-    let endDate:Date
+    public let title: String
+    public let startDate: Date
+    public let endDate:Date
     
     public init(title: String, startDate: Date, endDate: Date) {
         self.title = title;
@@ -366,7 +366,7 @@ extension CalendarView {
         goToMonthWithOffet(-1)
     }
     
-    func loadEvents(onComplete: ((Error?) -> Void)? = nil) {
+    public func loadEvents(onComplete: ((Error?) -> Void)? = nil) {
         
         EventsManager.load(from: self.startDateCache, to: self.endDateCache) { // (events:[CalendarEvent]?) in
             


### PR DESCRIPTION
By not adding public to these variables/functions it caused an error, aka - "X is inaccessable due to 'internal' protection level". Adding 'public' fixes that that error.