### PR TITLE
Compatible with Swift 4.2

### DIFF
--- a/CalendarView.xcodeproj/project.pbxproj
+++ b/CalendarView.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -595,6 +596,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/KDCalendar.podspec
+++ b/KDCalendar.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "KDCalendar"
-  s.version      = "1.6.2"
+  s.version      = "1.6.3"
   s.summary      = "A calendar component with native events support."
 
   s.description  = <<-DESC

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -130,12 +130,21 @@ public class CalendarView: UIView {
     public var delegate: CalendarViewDelegate?
     public var dataSource: CalendarViewDataSource?
     
+    #if swift(>=4.2)
+    public var direction : UICollectionView.ScrollDirection = .horizontal {
+        didSet {
+            flowLayout.scrollDirection = direction
+            self.collectionView.reloadData()
+        }
+    }
+    #else
     public var direction : UICollectionViewScrollDirection = .horizontal {
         didSet {
             flowLayout.scrollDirection = direction
             self.collectionView.reloadData()
         }
     }
+    #endif
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -189,9 +198,15 @@ public class CalendarView: UIView {
     
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
         
+        #if swift(>=4.2)
+        guard gesture.state == UIGestureRecognizer.State.began else {
+            return
+        }
+        #else
         guard gesture.state == UIGestureRecognizerState.began else {
             return
         }
+        #endif
         
         let point = gesture.location(in: collectionView)
         
@@ -334,7 +349,12 @@ extension CalendarView {
      */
     public func selectDate(_ date : Date) {
         guard let indexPath = self.indexPathForDate(date) else { return }
-        self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition())
+        
+        #if swift(>=4.2)
+        self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: UICollectionView.ScrollPosition())
+        #else
+            self.collectionView.selectItem(at: indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition())
+        #endif
         self.collectionView(collectionView, didSelectItemAt: indexPath)
     }
     


### PR DESCRIPTION
The calendar now compiles both with Swift 4 as well with Swift 4.2

Also updated the podspec with increased version number