### PR TITLE
Add iOS 8.0 support

### DIFF
--- a/KDCalendar.podspec
+++ b/KDCalendar.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.author       = "Michael Michailidis"
 
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "8.0"
 
   s.source       = { :git => "https://github.com/mmick66/CalendarView.git", :tag => s.version }
 

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -187,7 +187,9 @@ public class CalendarView: UIView {
         self.collectionView.showsVerticalScrollIndicator    = false
         self.collectionView.allowsMultipleSelection         = false
         self.collectionView.register(CalendarDayCell.self, forCellWithReuseIdentifier: cellReuseIdentifier)
-        self.collectionView.semanticContentAttribute = .forceLeftToRight // forces western style language orientation
+        if #available(iOS 9.0, *) {
+            self.collectionView.semanticContentAttribute = .forceLeftToRight // forces western style language orientation
+        }
         self.addSubview(self.collectionView)
         
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(CalendarView.handleLongPress))


### PR DESCRIPTION
iOS 8.0 is mentioned here - https://github.com/mmick66/CalendarView#requirements
but in the podspec file: s.platform     = :ios, "9.0"
I have decreased platform version in the podspec file.
And only one change was required in order to add iOS 8.0 support.