### PR TITLE
fix bug that cell selected colors not hooked up

### DIFF
--- a/KDCalendar/CalendarView/CalendarDayCell.swift
+++ b/KDCalendar/CalendarView/CalendarDayCell.swift
@@ -55,7 +55,7 @@ open class CalendarDayCell: UICollectionViewCell {
     
     var isWeekend: Bool = false {
         didSet {
-            if self.isToday { return }
+            if self.isSelected || self.isToday { return }
             switch isWeekend {
             case true:
                 self.textLabel.textColor = CalendarView.Style.cellTextColorWeekend
@@ -71,9 +71,12 @@ open class CalendarDayCell: UICollectionViewCell {
             case true:
                 self.bgView.layer.borderColor = CalendarView.Style.cellSelectedBorderColor.cgColor
                 self.bgView.layer.borderWidth = CalendarView.Style.cellSelectedBorderWidth
+                self.bgView.backgroundColor = CalendarView.Style.cellSelectedColor
+                self.textLabel.textColor = CalendarView.Style.cellSelectedTextColor
             case false:
                 self.bgView.layer.borderColor = CalendarView.Style.cellBorderColor.cgColor
                 self.bgView.layer.borderWidth = CalendarView.Style.cellBorderWidth
+                self.bgView.backgroundColor = CalendarView.Style.cellColorDefault
             }
         }
     }


### PR DESCRIPTION
#### What's this PR do?

I just wanted to fix bug that cell selected colors not hooked up

Please review in your free time... 😄 

If you find mistakes please tell me

#### Where should the reviewer start?

`KDCalendar/CalendarView/CalendarDayCell.swift`

#### How should this be manually tested?

add following code to `ViewController.swift`

```swift
   override func viewDidLoad() {
        
        super.viewDidLoad()
        ...
        CalendarView.Style.cellSelectedColor        = UIColor.orange
        CalendarView.Style.cellSelectedTextColor    = UIColor.red
        CalendarView.Style.cellTextColorToday       = UIColor.blue
       ...

  }
```

#### Any background context you want to provide?

I think we should use early return to prevent override cellSelectedTextColor.
Please see following code.

```
    var isWeekend: Bool = false {
        didSet {
            if self.isSelected || self.isToday { return }
```


#### What are the relevant tickets?

#58 

#### Screenshots (if appropriate)

![2019-02-27 0 23 06](https://user-images.githubusercontent.com/901084/53424175-13640100-3a26-11e9-9540-99ee7ee091fb.png)

