### PR TITLE
Added new font customization properties

### DIFF
--- a/KDCalendar/CalendarView/CalendarDayCell.swift
+++ b/KDCalendar/CalendarView/CalendarDayCell.swift
@@ -95,6 +95,9 @@ open class CalendarDayCell: UICollectionViewCell {
         
         self.dotsView.backgroundColor = CalendarView.Style.cellEventColor
         
+        self.textLabel.font = CalendarView.Style.cellFont
+        
+        
         super.init(frame: frame)
         
         self.addSubview(self.bgView)

--- a/KDCalendar/CalendarView/CalendarHeaderView.swift
+++ b/KDCalendar/CalendarView/CalendarHeaderView.swift
@@ -30,7 +30,7 @@ open class CalendarHeaderView: UIView {
     lazy var monthLabel : UILabel = {
         let lbl = UILabel()
         lbl.textAlignment = NSTextAlignment.center
-        lbl.font = UIFont(name: CalendarView.Style.headerFontName, size: CalendarView.Style.headerFontSize)
+        lbl.font = CalendarView.Style.headerFont
         lbl.textColor = CalendarView.Style.headerTextColor
         
         self.addSubview(lbl)
@@ -51,7 +51,7 @@ open class CalendarHeaderView: UIView {
             
             let weekdayLabel = UILabel()
             
-            weekdayLabel.font = UIFont(name: CalendarView.Style.headerFontName, size: 14.0)
+            weekdayLabel.font = CalendarView.Style.subHeaderFont
             
             weekdayLabel.text = formatter.shortWeekdaySymbols[(index % 7)].capitalized
             

--- a/KDCalendar/CalendarView/CalendarView+Style.swift
+++ b/KDCalendar/CalendarView/CalendarView+Style.swift
@@ -50,6 +50,7 @@ extension CalendarView {
         public static var cellTextColorDefault      = UIColor.gray
         public static var cellBorderColor           = UIColor.clear
         public static var cellBorderWidth           = CGFloat(0.0)
+        public static var cellFont                  = UIFont(name: "Helvetica", size: 17.0)
         
         //Today Style
         public static var cellTextColorToday        = UIColor.gray

--- a/KDCalendar/CalendarView/CalendarView+Style.swift
+++ b/KDCalendar/CalendarView/CalendarView+Style.swift
@@ -35,10 +35,10 @@ extension CalendarView {
         public static var cellEventColor = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.8)
         
         //Header
-        public static var headerHeight: CGFloat = 80.0
-        public static var headerTextColor = UIColor.gray
-        public static var headerFontName: String = "Helvetica"
-        public static var headerFontSize: CGFloat = 20.0
+        public static var headerHeight: CGFloat     = 80.0
+        public static var headerTextColor           = UIColor.gray
+        public static var headerFont                = UIFont(name: "Helvetica", size: 20.0) // Used for the month
+        public static var subHeaderFont             = UIFont(name: "Helvetica", size: 14.0) // Used for days of the week
 
         //Common
         public static var cellShape                 = CellShapeOptions.bevel(4.0)

--- a/KDCalendar/ViewController.swift
+++ b/KDCalendar/ViewController.swift
@@ -56,7 +56,9 @@ class ViewController: UIViewController, CalendarViewDataSource, CalendarViewDele
         CalendarView.Style.changeCellColorOutsideRange = false
         
         CalendarView.Style.cellFont = UIFont(name: "Helvetica", size: 20.0)
-
+        CalendarView.Style.headerFont = UIFont(name: "Helvetica", size: 20.0)
+        CalendarView.Style.subHeaderFont = UIFont(name: "Helvetica", size: 14.0)
+        
         calendarView.dataSource = self
         calendarView.delegate = self
         

--- a/KDCalendar/ViewController.swift
+++ b/KDCalendar/ViewController.swift
@@ -55,6 +55,8 @@ class ViewController: UIViewController, CalendarViewDataSource, CalendarViewDele
         CalendarView.Style.hideCellsOutsideDateRange = false
         CalendarView.Style.changeCellColorOutsideRange = false
         
+        CalendarView.Style.cellFont = UIFont(name: "Helvetica", size: 20.0)
+
         calendarView.dataSource = self
         calendarView.delegate = self
         


### PR DESCRIPTION
- Added font customization for the cells in CalendarView+Styles.  Used a UIFont property rather than a fontName:String and fontSize:CGFloat in order to allow the use of UIFont.systemFont() to choose fonts from the San Francisco family.
- Changed the header font customization to use a UIFont property rather than headerFontName and headerFontSize
- Added a subheader font customization property since it was formerly a derivative of headerFontName with a fixed size.