### PR TITLE
Resolving an issue where certain sizes of calendar view caused poor month offset paging

### DIFF
--- a/CalendarView.xcodeproj/project.pbxproj
+++ b/CalendarView.xcodeproj/project.pbxproj
@@ -293,7 +293,6 @@
 					};
 					BEFD654E1ACC072000ADE917 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 45H8MG9FJ4;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -612,7 +611,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 45H8MG9FJ4;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = KDCalendar/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -631,7 +630,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 45H8MG9FJ4;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = KDCalendar/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/CalendarView.xcodeproj/project.pbxproj
+++ b/CalendarView.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 					};
 					BEFD654E1ACC072000ADE917 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = Dev;
+						DevelopmentTeam = 45H8MG9FJ4;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
@@ -612,7 +612,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Dev;
+				DEVELOPMENT_TEAM = 45H8MG9FJ4;
 				INFOPLIST_FILE = KDCalendar/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -631,7 +631,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Dev;
+				DEVELOPMENT_TEAM = 45H8MG9FJ4;
 				INFOPLIST_FILE = KDCalendar/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -92,8 +92,14 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
         var page: Int = 0
         
         switch self.direction {
-        case .horizontal:   page = Int(floor(self.collectionView.contentOffset.x / self.collectionView.bounds.size.width))
-        case .vertical:     page = Int(floor(self.collectionView.contentOffset.y / self.collectionView.bounds.size.height))
+        case .horizontal:
+            let offsetX = ceilf(Float(self.collectionView.contentOffset.x))
+            let width = self.collectionView.bounds.size.width
+            page = Int(floor(offsetX / Float(width)))
+        case .vertical:
+            let offsetY = ceilf(Float(self.collectionView.contentOffset.y))
+            let width = self.collectionView.bounds.size.width
+            page = Int(floor(offsetY / Float(width)))
         @unknown default:
             fatalError()
         }

--- a/KDCalendar/ViewController.swift
+++ b/KDCalendar/ViewController.swift
@@ -105,7 +105,7 @@ class ViewController: UIViewController, CalendarViewDataSource, CalendarViewDele
     func startDate() -> Date {
         
         var dateComponents = DateComponents()
-        dateComponents.month = -3
+        dateComponents.month = 0
         
         let today = Date()
         
@@ -118,7 +118,7 @@ class ViewController: UIViewController, CalendarViewDataSource, CalendarViewDele
         
         var dateComponents = DateComponents()
       
-        dateComponents.month = 3
+        dateComponents.month = 12
         let today = Date()
         
         let twoYearsFromNow = self.calendarView.calendar.date(byAdding: dateComponents, to: today)!


### PR DESCRIPTION
I just stumbled upon a size of calendar view that was causing problems when changing months due to an offset that was slightly off for certain months. This would cause pretty big issues with scrolling and cause months to be off or repeated. Feel free to merge the pull request or ignore it but I would consider utilizing the changes made to CalendarView+Delegate.swift as it does solve a rather annoying issue that I stumbled upon and took a few hours to solve.