### PR TITLE
Feature/refactor

### DIFF
--- a/KDCalendar/CalendarView/CalendarDayCell.swift
+++ b/KDCalendar/CalendarView/CalendarDayCell.swift
@@ -62,7 +62,6 @@ open class CalendarDayCell: UICollectionViewCell {
                 self.bgView.backgroundColor = style.cellColorDefault
                 self.textLabel.textColor = style.cellTextColorDefault
             }
-            
         }
     }
     
@@ -107,7 +106,6 @@ open class CalendarDayCell: UICollectionViewCell {
                 } else {
                     self.bgView.backgroundColor = style.cellColorDefault
                 }
-                
             }
         }
     }
@@ -180,7 +178,6 @@ open class CalendarDayCell: UICollectionViewCell {
         case .bevel(let radius):
             self.bgView.layer.cornerRadius = radius
         }
-        
         
         
     }

--- a/KDCalendar/CalendarView/CalendarDayCell.swift
+++ b/KDCalendar/CalendarView/CalendarDayCell.swift
@@ -27,6 +27,8 @@ import UIKit
 
 open class CalendarDayCell: UICollectionViewCell {
     
+    var style: CalendarView.Style = CalendarView.Style.Default
+    
     override open var description: String {
         let dayString = self.textLabel.text ?? " "
         return "<DayCell (text:\"\(dayString)\")>"
@@ -54,11 +56,11 @@ open class CalendarDayCell: UICollectionViewCell {
         didSet {
             switch isToday {
             case true:
-                self.bgView.backgroundColor = CalendarView.Style.cellColorToday
-                self.textLabel.textColor    = CalendarView.Style.cellTextColorToday
+                self.bgView.backgroundColor = style.cellColorToday
+                self.textLabel.textColor    = style.cellTextColorToday
             case false:
-                self.bgView.backgroundColor = CalendarView.Style.cellColorDefault
-                self.textLabel.textColor = CalendarView.Style.cellTextColorDefault
+                self.bgView.backgroundColor = style.cellColorDefault
+                self.textLabel.textColor = style.cellTextColorDefault
             }
             
         }
@@ -69,9 +71,9 @@ open class CalendarDayCell: UICollectionViewCell {
         didSet {
             switch isOutOfRange {
             case true:
-                self.textLabel.textColor = CalendarView.Style.cellColorOutOfRange
+                self.textLabel.textColor = style.cellColorOutOfRange
             case false:
-                self.textLabel.textColor = CalendarView.Style.cellTextColorDefault
+                self.textLabel.textColor = style.cellTextColorDefault
             }
         }
     }
@@ -82,9 +84,9 @@ open class CalendarDayCell: UICollectionViewCell {
             if self.isSelected || self.isToday { return }
             switch isWeekend {
             case true:
-                self.textLabel.textColor = CalendarView.Style.cellTextColorWeekend
+                self.textLabel.textColor = style.cellTextColorWeekend
             case false:
-                self.textLabel.textColor = CalendarView.Style.cellTextColorDefault
+                self.textLabel.textColor = style.cellTextColorDefault
             }
         }
     }
@@ -93,17 +95,17 @@ open class CalendarDayCell: UICollectionViewCell {
         didSet {
             switch isSelected {
             case true:
-                self.bgView.layer.borderColor = CalendarView.Style.cellSelectedBorderColor.cgColor
-                self.bgView.layer.borderWidth = CalendarView.Style.cellSelectedBorderWidth
-                self.bgView.backgroundColor = CalendarView.Style.cellSelectedColor
-                self.textLabel.textColor = CalendarView.Style.cellSelectedTextColor
+                self.bgView.layer.borderColor = style.cellSelectedBorderColor.cgColor
+                self.bgView.layer.borderWidth = style.cellSelectedBorderWidth
+                self.bgView.backgroundColor = style.cellSelectedColor
+                self.textLabel.textColor = style.cellSelectedTextColor
             case false:
-                self.bgView.layer.borderColor = CalendarView.Style.cellBorderColor.cgColor
-                self.bgView.layer.borderWidth = CalendarView.Style.cellBorderWidth
+                self.bgView.layer.borderColor = style.cellBorderColor.cgColor
+                self.bgView.layer.borderWidth = style.cellBorderWidth
                 if self.isToday {
-                    self.bgView.backgroundColor = CalendarView.Style.cellColorToday
+                    self.bgView.backgroundColor = style.cellColorToday
                 } else {
-                    self.bgView.backgroundColor = CalendarView.Style.cellColorDefault
+                    self.bgView.backgroundColor = style.cellColorDefault
                 }
                 
             }
@@ -112,10 +114,10 @@ open class CalendarDayCell: UICollectionViewCell {
     
     // MARK: - Public methods
     public func clearStyles() {
-        self.bgView.layer.borderColor = CalendarView.Style.cellBorderColor.cgColor
-        self.bgView.layer.borderWidth = CalendarView.Style.cellBorderWidth
-        self.bgView.backgroundColor = CalendarView.Style.cellColorDefault
-        self.textLabel.textColor = CalendarView.Style.cellTextColorDefault
+        self.bgView.layer.borderColor = style.cellBorderColor.cgColor
+        self.bgView.layer.borderWidth = style.cellBorderWidth
+        self.bgView.backgroundColor = style.cellColorDefault
+        self.textLabel.textColor = style.cellTextColorDefault
         self.eventsCount = 0
     }
     
@@ -129,9 +131,9 @@ open class CalendarDayCell: UICollectionViewCell {
         self.textLabel.textAlignment = NSTextAlignment.center
         
         
-        self.dotsView.backgroundColor = CalendarView.Style.cellEventColor
+        self.dotsView.backgroundColor = style.cellEventColor
         
-        self.textLabel.font = CalendarView.Style.cellFont
+        self.textLabel.font = style.cellFont
         
         
         super.init(frame: frame)
@@ -154,7 +156,7 @@ open class CalendarDayCell: UICollectionViewCell {
         
         var elementsFrame = self.bounds.insetBy(dx: 3.0, dy: 3.0)
         
-        if CalendarView.Style.cellShape.isRound { // square of
+        if style.cellShape.isRound { // square of
             let smallestSide = min(elementsFrame.width, elementsFrame.height)
             elementsFrame = elementsFrame.insetBy(
                 dx: (elementsFrame.width - smallestSide) / 2.0,
@@ -170,7 +172,7 @@ open class CalendarDayCell: UICollectionViewCell {
         self.dotsView.center                = CGPoint(x: self.textLabel.center.x, y: self.bounds.height - (2.5 * size))
         self.dotsView.layer.cornerRadius    = size * 0.5 // round it
         
-        switch CalendarView.Style.cellShape {
+        switch style.cellShape {
         case .square:
             self.bgView.layer.cornerRadius = 0.0
         case .round:

--- a/KDCalendar/CalendarView/CalendarDayCell.swift
+++ b/KDCalendar/CalendarView/CalendarDayCell.swift
@@ -52,41 +52,55 @@ open class CalendarDayCell: UICollectionViewCell {
         }
     }
     
+    func updateTextColor() {
+        if isSelected {
+            self.textLabel.textColor = style.cellSelectedTextColor
+        }
+        else if isToday {
+            self.textLabel.textColor = style.cellTextColorToday
+        }
+        else if isOutOfRange {
+            self.textLabel.textColor = style.cellColorOutOfRange
+        }
+        else if isAdjacent {
+            self.textLabel.textColor = style.cellColorAdjacent
+        }
+        else if isWeekend {
+            self.textLabel.textColor = style.cellTextColorWeekend
+        }
+        else {
+            self.textLabel.textColor = style.cellTextColorDefault
+        }
+    }
+    
     var isToday : Bool = false {
         didSet {
             switch isToday {
             case true:
                 self.bgView.backgroundColor = style.cellColorToday
-                self.textLabel.textColor    = style.cellTextColorToday
             case false:
                 self.bgView.backgroundColor = style.cellColorDefault
-                self.textLabel.textColor = style.cellTextColorDefault
             }
+            
+            updateTextColor()
         }
     }
-    
     
     var isOutOfRange : Bool = false {
         didSet {
-            switch isOutOfRange {
-            case true:
-                self.textLabel.textColor = style.cellColorOutOfRange
-            case false:
-                self.textLabel.textColor = style.cellTextColorDefault
-            }
+            updateTextColor()
         }
     }
     
+    var isAdjacent : Bool = false {
+        didSet {
+            updateTextColor()
+        }
+    }
     
     var isWeekend: Bool = false {
         didSet {
-            if self.isSelected || self.isToday { return }
-            switch isWeekend {
-            case true:
-                self.textLabel.textColor = style.cellTextColorWeekend
-            case false:
-                self.textLabel.textColor = style.cellTextColorDefault
-            }
+            updateTextColor()
         }
     }
     
@@ -97,7 +111,6 @@ open class CalendarDayCell: UICollectionViewCell {
                 self.bgView.layer.borderColor = style.cellSelectedBorderColor.cgColor
                 self.bgView.layer.borderWidth = style.cellSelectedBorderWidth
                 self.bgView.backgroundColor = style.cellSelectedColor
-                self.textLabel.textColor = style.cellSelectedTextColor
             case false:
                 self.bgView.layer.borderColor = style.cellBorderColor.cgColor
                 self.bgView.layer.borderWidth = style.cellBorderWidth
@@ -107,6 +120,8 @@ open class CalendarDayCell: UICollectionViewCell {
                     self.bgView.backgroundColor = style.cellColorDefault
                 }
             }
+            
+            updateTextColor()
         }
     }
     

--- a/KDCalendar/CalendarView/CalendarHeaderView.swift
+++ b/KDCalendar/CalendarView/CalendarHeaderView.swift
@@ -27,69 +27,106 @@ import UIKit
 
 open class CalendarHeaderView: UIView {
     
-    var style: CalendarView.Style = CalendarView.Style.Default
+    var style: CalendarView.Style = CalendarView.Style.Default {
+        didSet {
+            updateStyle()
+        }
+    }
     
-    lazy var monthLabel : UILabel = {
-        let lbl = UILabel()
-        lbl.textAlignment = NSTextAlignment.center
-        lbl.font = style.headerFont
-        lbl.textColor = style.headerTextColor
-        
-        self.addSubview(lbl)
-        
-        return lbl
-    }()
+    var monthLabel: UILabel!
     
-    lazy var dayLabelContainerView : UIView = {
-        let v = UIView()
+    var dayLabels = [UILabel]()
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.translatesAutoresizingMaskIntoConstraints = false
+        
+        monthLabel = UILabel()
+        monthLabel.translatesAutoresizingMaskIntoConstraints = false
+        monthLabel.backgroundColor = UIColor.clear
+        self.addSubview(monthLabel)
+        
+        for _ in 0..<7 {
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.backgroundColor = UIColor.clear
+            
+            dayLabels.append(label)
+            self.addSubview(label)
+        }
+    }
+    
+    public func updateStyle() {
+        self.monthLabel.textAlignment = NSTextAlignment.center
+        self.monthLabel.font = style.headerFont
+        self.monthLabel.textColor = style.headerTextColor
+        self.monthLabel.backgroundColor = style.headerBackgroundColor
         
         let formatter = DateFormatter()
         formatter.locale = style.locale
-        formatter.timeZone = style.timeZone
+        formatter.timeZone = style.calendar.timeZone
         
-        var start = style.firstWeekday == .sunday ? 0 : 1
+        let start = style.firstWeekday == .sunday ? 0 : 1
+        var i = 0
         
         for index in start..<(start+7) {
+            let label = dayLabels[i]
+            label.font = style.weekdaysFont
+            label.text = formatter.shortWeekdaySymbols[(index % 7)].capitalized
+            label.textColor = style.weekdaysTextColor
+            label.textAlignment = .center
             
-            let weekdayLabel = UILabel()
-            
-            weekdayLabel.font = style.subHeaderFont
-            
-            weekdayLabel.text = formatter.shortWeekdaySymbols[(index % 7)].capitalized
-            self.backgroundColor = style.headerBackgroundColor
-            weekdayLabel.textColor = style.headerTextColor
-            weekdayLabel.textAlignment = NSTextAlignment.center
-            
-            v.addSubview(weekdayLabel)
+            i = i + 1
         }
-        
-        self.addSubview(v)
-        
-        return v
-        
-    }()
+
+        self.backgroundColor = style.weekdaysBackgroundColor
+    }
+    
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override open func layoutSubviews() {
-        
         super.layoutSubviews()
         
-        var frm = self.bounds
-        frm.origin.y += 5.0
-        frm.size.height = self.bounds.size.height / 2.0 - 5.0
+        var isRtl = UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
         
-        self.monthLabel.frame = frm
+        if #available(iOS 10.0, *) {
+            isRtl = self.effectiveUserInterfaceLayoutDirection == .rightToLeft
+        }
+        else if #available(iOS 9.0, *) {
+            isRtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
+        }
+        
+        self.monthLabel?.frame = CGRect(
+            x: 0.0,
+            y: style.headerTopMargin,
+            width: self.bounds.size.width,
+            height: self.bounds.size.height
+                - style.headerTopMargin
+                - style.weekdaysHeight
+                - style.weekdaysBottomMargin
+                - style.weekdaysTopMargin
+        )
         
         var labelFrame = CGRect(
             x: 0.0,
-            y: self.bounds.size.height / 2.0,
+            y: self.bounds.size.height
+                - style.weekdaysBottomMargin
+                - style.weekdaysHeight,
             width: self.bounds.size.width / 7.0,
-            height: self.bounds.size.height / 2.0
+            height: style.weekdaysHeight
         )
         
-        for lbl in self.dayLabelContainerView.subviews {
-            
+        if isRtl {
+            labelFrame.origin.x = self.bounds.size.width - labelFrame.width
+        }
+        
+        for lbl in self.dayLabels {
             lbl.frame = labelFrame
-            labelFrame.origin.x += labelFrame.size.width
+            
+            labelFrame.origin.x += isRtl ? -labelFrame.size.width : labelFrame.size.width
         }
     }
 }

--- a/KDCalendar/CalendarView/CalendarHeaderView.swift
+++ b/KDCalendar/CalendarView/CalendarHeaderView.swift
@@ -27,11 +27,13 @@ import UIKit
 
 open class CalendarHeaderView: UIView {
     
+    var style: CalendarView.Style = CalendarView.Style.Default
+    
     lazy var monthLabel : UILabel = {
         let lbl = UILabel()
         lbl.textAlignment = NSTextAlignment.center
-        lbl.font = CalendarView.Style.headerFont
-        lbl.textColor = CalendarView.Style.headerTextColor
+        lbl.font = style.headerFont
+        lbl.textColor = style.headerTextColor
         
         self.addSubview(lbl)
         
@@ -42,20 +44,20 @@ open class CalendarHeaderView: UIView {
         let v = UIView()
         
         let formatter = DateFormatter()
-        formatter.locale = CalendarView.Style.locale
-        formatter.timeZone = CalendarView.Style.timeZone
+        formatter.locale = style.locale
+        formatter.timeZone = style.timeZone
         
-        var start = CalendarView.Style.firstWeekday == .sunday ? 0 : 1
+        var start = style.firstWeekday == .sunday ? 0 : 1
         
         for index in start..<(start+7) {
             
             let weekdayLabel = UILabel()
             
-            weekdayLabel.font = CalendarView.Style.subHeaderFont
+            weekdayLabel.font = style.subHeaderFont
             
             weekdayLabel.text = formatter.shortWeekdaySymbols[(index % 7)].capitalized
-            self.backgroundColor = CalendarView.Style.headerBackgroundColor
-            weekdayLabel.textColor = CalendarView.Style.headerTextColor
+            self.backgroundColor = style.headerBackgroundColor
+            weekdayLabel.textColor = style.headerTextColor
             weekdayLabel.textAlignment = NSTextAlignment.center
             
             v.addSubview(weekdayLabel)

--- a/KDCalendar/CalendarView/CalendarView+DataSource.swift
+++ b/KDCalendar/CalendarView/CalendarView+DataSource.swift
@@ -80,7 +80,7 @@ extension CalendarView: UICollectionViewDataSource {
     public func getMonthInfo(for date: Date) -> (firstDay: Int, daysTotal: Int)? {
         
         var firstWeekdayOfMonthIndex    = self.calendar.component(.weekday, from: date)
-        firstWeekdayOfMonthIndex       -= CalendarView.Style.firstWeekday == .monday ? 1 : 0 
+        firstWeekdayOfMonthIndex       -= style.firstWeekday == .monday ? 1 : 0
         firstWeekdayOfMonthIndex        = (firstWeekdayOfMonthIndex + 6) % 7 // push it modularly to map it in the range 0 to 6
         
         guard let rangeOfDaysInMonth = self.calendar.range(of: .day, in: .month, for: date) else { return nil }
@@ -110,6 +110,7 @@ extension CalendarView: UICollectionViewDataSource {
         
         let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as! CalendarDayCell
         
+        dayCell.style = style
         dayCell.clearStyles()
         
         guard let (firstDayIndex, numberOfDaysTotal) = self.monthInfoForSection[indexPath.section] else { return dayCell }
@@ -156,7 +157,7 @@ extension CalendarView: UICollectionViewDataSource {
         
         if self.marksWeekends {
             let we = indexPath.item % 7
-            let weekDayOption = CalendarView.Style.firstWeekday == .sunday ? 0 : 5
+            let weekDayOption = style.firstWeekday == .sunday ? 0 : 5
             dayCell.isWeekend = we == weekDayOption || we == 6
         }
         

--- a/KDCalendar/CalendarView/CalendarView+DataSource.swift
+++ b/KDCalendar/CalendarView/CalendarView+DataSource.swift
@@ -169,18 +169,40 @@ extension CalendarView: UICollectionViewDataSource {
             }
             return false
         }
+        
+        let isInRange = (firstDayIndex..<lastDayIndex).contains(indexPath.item)
+        let isAdjacent = !isInRange && style.showAdjacentDays && (
+            indexPath.item < firstDayIndex || indexPath.item >= lastDayIndex
+        )
     
         // the index of this cell is within the range of first and the last day of the month
-        if (firstDayIndex..<lastDayIndex).contains(indexPath.item) {
-            // ex. if the first is wednesday (index of 3), subtract 2 to show it as 1
-            dayCell.day = (indexPath.item - firstDayIndex) + 1
+        if isInRange || isAdjacent {
             dayCell.isHidden = false
             
+            if isAdjacent {
+                if indexPath.item < firstDayIndex {
+                    if let prevInfo = self.getCachedSectionInfo(indexPath.section - 1) {
+                        dayCell.day = prevInfo.daysTotal - firstDayIndex + indexPath.item
+                    }
+                    else {
+                        dayCell.isHidden = true
+                    }
+                }
+                else {
+                    dayCell.day = indexPath.item - lastDayIndex + 1
+                }
+            }
+            else {
+                // ex. if the first is wednesday (index of 3), subtract 2 to show it as 1
+                dayCell.day = (indexPath.item - firstDayIndex) + 1
+            }
+            
+            dayCell.isAdjacent = isAdjacent
             dayCell.isOutOfRange = cellOutOfRange(indexPath)
             
         } else {
-            dayCell.textLabel.text = ""
             dayCell.isHidden = true
+            dayCell.textLabel.text = ""
         }
         
         // hack: send once at the beginning

--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -109,7 +109,7 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
         var monthsOffsetComponents = DateComponents()
         monthsOffsetComponents.month = page
         
-        return self.calendar.date(byAdding: monthsOffsetComponents, to: self.startOfMonthCache);
+        return self.calendar.date(byAdding: monthsOffsetComponents, to: self.firstDayCache);
     }
     
     func displayDateOnHeader(_ date: Date) {
@@ -117,7 +117,7 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
         
         let formatter = DateFormatter()
         formatter.locale = style.locale
-        formatter.timeZone = style.timeZone
+        formatter.timeZone = style.calendar.timeZone
         
         let monthName = formatter.monthSymbols[(month-1) % 12].capitalized // 0 indexed array
         

--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -116,8 +116,8 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
         let month = self.calendar.component(.month, from: date) // get month
         
         let formatter = DateFormatter()
-        formatter.locale = CalendarView.Style.locale
-        formatter.timeZone = CalendarView.Style.timeZone
+        formatter.locale = style.locale
+        formatter.timeZone = style.timeZone
         
         let monthName = formatter.monthSymbols[(month-1) % 12].capitalized // 0 indexed array
         

--- a/KDCalendar/CalendarView/CalendarView+Style.swift
+++ b/KDCalendar/CalendarView/CalendarView+Style.swift
@@ -64,6 +64,7 @@ extension CalendarView {
         public var cellShape                 = CellShapeOptions.bevel(4.0)
         
         public var firstWeekday              = FirstWeekdayOptions.monday
+        public var showAdjacentDays          = false
         
         //Default Style
         public var cellColorDefault          = UIColor(white: 0.0, alpha: 0.1)
@@ -76,6 +77,7 @@ extension CalendarView {
         public var cellTextColorToday        = UIColor.gray
         public var cellColorToday            = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.3)
         public var cellColorOutOfRange       = UIColor(white: 0.0, alpha: 0.5)
+        public var cellColorAdjacent         = UIColor.clear
         
         //Selected Style
         public var cellSelectedBorderColor   = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.8)

--- a/KDCalendar/CalendarView/CalendarView+Style.swift
+++ b/KDCalendar/CalendarView/CalendarView+Style.swift
@@ -10,7 +10,9 @@ import UIKit
 
 extension CalendarView {
     
-    public struct Style {
+    public class Style {
+        
+        public static var Default: Style = Style()
         
         public enum CellShapeOptions {
             case round
@@ -37,51 +39,53 @@ extension CalendarView {
             case grayed
         }
         
+        public init()
+        {
+        }
+        
         //Event
-        public static var cellEventColor = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.8)
+        public var cellEventColor = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.8)
         
         //Header
-        public static var headerHeight: CGFloat     = 80.0
-        public static var headerTextColor           = UIColor.gray
-        public static var headerBackgroundColor     = UIColor.white
-        public static var headerFont                = UIFont.systemFont(ofSize: 20) // Used for the month
-        public static var subHeaderFont             = UIFont.systemFont(ofSize: 14) // Used for days of the week
+        public var headerHeight: CGFloat     = 80.0
+        public var headerTextColor           = UIColor.gray
+        public var headerBackgroundColor     = UIColor.white
+        public var headerFont                = UIFont.systemFont(ofSize: 20) // Used for the month
+        public var subHeaderFont             = UIFont.systemFont(ofSize: 14) // Used for days of the week
         
         //Common
-        public static var cellShape                 = CellShapeOptions.bevel(4.0)
+        public var cellShape                 = CellShapeOptions.bevel(4.0)
         
-        public static var firstWeekday              = FirstWeekdayOptions.monday
+        public var firstWeekday              = FirstWeekdayOptions.monday
         
         //Default Style
-        public static var cellColorDefault          = UIColor(white: 0.0, alpha: 0.1)
-        public static var cellTextColorDefault      = UIColor.gray
-        public static var cellBorderColor           = UIColor.clear
-        public static var cellBorderWidth           = CGFloat(0.0)
-        public static var cellFont                  = UIFont.systemFont(ofSize: 17)
+        public var cellColorDefault          = UIColor(white: 0.0, alpha: 0.1)
+        public var cellTextColorDefault      = UIColor.gray
+        public var cellBorderColor           = UIColor.clear
+        public var cellBorderWidth           = CGFloat(0.0)
+        public var cellFont                  = UIFont.systemFont(ofSize: 17)
         
         //Today Style
-        public static var cellTextColorToday        = UIColor.gray
-        public static var cellColorToday            = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.3)
-        public static var cellColorOutOfRange       = UIColor(white: 0.0, alpha: 0.5)
+        public var cellTextColorToday        = UIColor.gray
+        public var cellColorToday            = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.3)
+        public var cellColorOutOfRange       = UIColor(white: 0.0, alpha: 0.5)
         
         //Selected Style
-        public static var cellSelectedBorderColor   = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.8)
-        public static var cellSelectedBorderWidth   = CGFloat(2.0)
-        public static var cellSelectedColor         = UIColor.clear
-        public static var cellSelectedTextColor     = UIColor.black
+        public var cellSelectedBorderColor   = UIColor(red: 254.0/255.0, green: 73.0/255.0, blue: 64.0/255.0, alpha: 0.8)
+        public var cellSelectedBorderWidth   = CGFloat(2.0)
+        public var cellSelectedColor         = UIColor.clear
+        public var cellSelectedTextColor     = UIColor.black
         
         //Weekend Style
-        public static var cellTextColorWeekend      = UIColor(red:1.00, green:0.84, blue:0.65, alpha:1.00)
+        public var cellTextColorWeekend      = UIColor(red:1.00, green:0.84, blue:0.65, alpha:1.00)
         
         //Locale Style
-        public static var locale                    = Locale.current
+        public var locale                    = Locale.current
         
         //TimeZone Calendar Style
-        public static var timeZone                  = TimeZone(abbreviation: "UTC")!
+        public var timeZone                  = TimeZone(abbreviation: "UTC")!
         
         //Calendar Identifier Style
-        public static var identifier                = Calendar.Identifier.gregorian
-        
-        
+        public var identifier                = Calendar.Identifier.gregorian
     }
 }

--- a/KDCalendar/CalendarView/CalendarView+Style.swift
+++ b/KDCalendar/CalendarView/CalendarView+Style.swift
@@ -48,10 +48,17 @@ extension CalendarView {
         
         //Header
         public var headerHeight: CGFloat     = 80.0
+        public var headerTopMargin: CGFloat  = 5.0
         public var headerTextColor           = UIColor.gray
         public var headerBackgroundColor     = UIColor.white
         public var headerFont                = UIFont.systemFont(ofSize: 20) // Used for the month
-        public var subHeaderFont             = UIFont.systemFont(ofSize: 14) // Used for days of the week
+        
+        public var weekdaysTopMargin: CGFloat     = 5.0
+        public var weekdaysBottomMargin: CGFloat  = 5.0
+        public var weekdaysHeight: CGFloat        = 35.0
+        public var weekdaysTextColor              = UIColor.gray
+        public var weekdaysBackgroundColor        = UIColor.white
+        public var weekdaysFont                   = UIFont.systemFont(ofSize: 14) // Used for days of the week
         
         //Common
         public var cellShape                 = CellShapeOptions.bevel(4.0)
@@ -83,9 +90,16 @@ extension CalendarView {
         public var locale                    = Locale.current
         
         //TimeZone Calendar Style
-        public var timeZone                  = TimeZone(abbreviation: "UTC")!
+        public var timeZone: TimeZone {
+            get { return calendar.timeZone }
+            set { calendar.timeZone = newValue }
+        }
         
         //Calendar Identifier Style
-        public var identifier                = Calendar.Identifier.gregorian
+        public lazy var calendar: Calendar   = {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(abbreviation: "UTC")!
+            return calendar
+        }()
     }
 }

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -90,9 +90,15 @@ public class CalendarView: UIView {
     var headerView: CalendarHeaderView!
     var collectionView: UICollectionView!
     
+    public var style: Style = Style.Default {
+        didSet {
+            self.headerView?.style = style
+        }
+    }
+    
     public lazy var calendar : Calendar = {
-        var calendarStyle = Calendar(identifier: CalendarView.Style.identifier)
-        calendarStyle.timeZone = CalendarView.Style.timeZone
+        var calendarStyle = Calendar(identifier: style.identifier)
+        calendarStyle.timeZone = style.timeZone
         return calendarStyle
     }()
     
@@ -178,6 +184,7 @@ public class CalendarView: UIView {
         
         /* Header View */
         self.headerView = CalendarHeaderView(frame:CGRect.zero)
+        self.headerView.style = style
         self.addSubview(self.headerView)
         
         /* Layout */
@@ -247,14 +254,14 @@ public class CalendarView: UIView {
             x:0.0,
             y:0.0,
             width: self.frame.size.width,
-            height: CalendarView.Style.headerHeight
+            height: style.headerHeight
         )
         
         self.collectionView.frame = CGRect(
             x: 0.0,
-            y: CalendarView.Style.headerHeight,
+            y: style.headerHeight,
             width: self.frame.size.width,
-            height: self.frame.size.height - CalendarView.Style.headerHeight
+            height: self.frame.size.height - style.headerHeight
         )
         
         flowLayout.itemSize = self.cellSize(in: self.bounds)
@@ -265,7 +272,7 @@ public class CalendarView: UIView {
     private func cellSize(in bounds: CGRect) -> CGSize {
         return CGSize(
             width:   frame.size.width / 7.0,                                    // number of days in week
-            height: (frame.size.height - CalendarView.Style.headerHeight) / 6.0 // maximum number of rows
+            height: (frame.size.height - style.headerHeight) / 6.0 // maximum number of rows
         )
     }
     

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -90,22 +90,26 @@ public class CalendarView: UIView {
     var headerView: CalendarHeaderView!
     var collectionView: UICollectionView!
     
-    public var style: Style = Style.Default {
+    public var forceLtr: Bool = true {
         didSet {
-            self.headerView?.style = style
+            updateLayoutDirections()
         }
     }
     
-    public lazy var calendar : Calendar = {
-        var calendarStyle = Calendar(identifier: style.identifier)
-        calendarStyle.timeZone = style.timeZone
-        return calendarStyle
-    }()
+    public var style: Style = Style.Default {
+        didSet {
+            updateStyle()
+        }
+    }
     
-    internal var startDateCache     = Date()
-    internal var endDateCache       = Date()
-    internal var startOfMonthCache  = Date()
-    internal var endOfMonthCache    = Date()
+    public var calendar : Calendar {
+        return style.calendar
+    }
+
+    internal var _startDateCache: Date?
+    internal var _endDateCache: Date?
+    internal var _firstDayCache: Date?
+    internal var _lastDayCache: Date?
     
     internal var todayIndexPath : IndexPath?
     internal var startIndexPath : IndexPath!
@@ -114,7 +118,7 @@ public class CalendarView: UIView {
     internal var selectedIndexPaths    = [IndexPath]()
     internal var selectedDates         = [Date]()
     
-    internal var monthInfoForSection = [Int:(firstDay: Int, daysTotal: Int)]()
+    internal var _cachedMonthInfoForSection = [Int:(firstDay: Int, daysTotal: Int)]()
     internal var eventsByIndexPath = [IndexPath: [CalendarEvent]]()
     
     public var events: [CalendarEvent] = [] {
@@ -139,7 +143,7 @@ public class CalendarView: UIView {
     
     // MARK: - public
     
-    public var displayDate: Date?
+    public internal(set) var displayDate: Date?
     public var multipleSelectionEnable = true
     public var enableDeslection = true
     public var marksWeekends = true
@@ -181,6 +185,7 @@ public class CalendarView: UIView {
     private func setup() {
         
         self.clipsToBounds = true
+        self.translatesAutoresizingMaskIntoConstraints = false
         
         /* Header View */
         self.headerView = CalendarHeaderView(frame:CGRect.zero)
@@ -205,16 +210,16 @@ public class CalendarView: UIView {
         self.collectionView.showsVerticalScrollIndicator    = false
         self.collectionView.allowsMultipleSelection         = false
         self.collectionView.register(CalendarDayCell.self, forCellWithReuseIdentifier: cellReuseIdentifier)
-        if #available(iOS 9.0, *) {
-            self.collectionView.semanticContentAttribute = .forceLeftToRight // forces western style language orientation
-        }
+        
         self.addSubview(self.collectionView)
+        
+        // Update semantic content attributes
+        updateLayoutDirections()
         
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(CalendarView.handleLongPress))
         self.collectionView.addGestureRecognizer(longPress)
         
     }
-    
     
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
         
@@ -247,17 +252,17 @@ public class CalendarView: UIView {
     }
     
     override open func layoutSubviews() {
-       
+        
         super.layoutSubviews()
         
-        self.headerView.frame = CGRect(
-            x:0.0,
-            y:0.0,
+        self.headerView?.frame = CGRect(
+            x: 0.0,
+            y: 0.0,
             width: self.frame.size.width,
             height: style.headerHeight
         )
         
-        self.collectionView.frame = CGRect(
+        self.collectionView?.frame = CGRect(
             x: 0.0,
             y: style.headerHeight,
             width: self.frame.size.width,
@@ -270,10 +275,51 @@ public class CalendarView: UIView {
     }
     
     private func cellSize(in bounds: CGRect) -> CGSize {
+        guard let collectionView = self.collectionView
+            else {
+                return CGSize(
+                    width: self.bounds.width / 7.0,
+                    height: self.bounds.width / 7.0
+                )
+            }
+        
         return CGSize(
-            width:   frame.size.width / 7.0,                                    // number of days in week
-            height: (frame.size.height - style.headerHeight) / 6.0 // maximum number of rows
+            width:   collectionView.bounds.width / 7.0,                                    // number of days in week
+            height: (collectionView.bounds.height) / 6.0 // maximum number of rows
         )
+    }
+    
+    internal var _isRtl = false
+    
+    internal func updateLayoutDirections() {
+        if #available(iOS 9.0, *) {
+            self.collectionView?.semanticContentAttribute = .forceLeftToRight
+            self.headerView?.semanticContentAttribute = forceLtr ? .forceLeftToRight : .unspecified
+        }
+        
+        var isRtl = false
+        
+        if !forceLtr
+        {
+            isRtl = UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
+            
+            if #available(iOS 10.0, *) {
+                isRtl = self.effectiveUserInterfaceLayoutDirection == .rightToLeft
+            }
+            else if #available(iOS 9.0, *) {
+                isRtl = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
+            }
+        }
+        
+        if _isRtl != isRtl
+        {
+            _isRtl = isRtl
+            
+            self.collectionView?.transform = isRtl
+                ? CGAffineTransform(scaleX: -1.0, y: 1.0)
+                : CGAffineTransform.identity
+            self.collectionView?.reloadData()
+        }
     }
     
     internal func resetDisplayDate() {
@@ -283,6 +329,10 @@ public class CalendarView: UIView {
             self.scrollViewOffset(for: displayDate),
             animated: false
         )
+    }
+    
+    internal func updateStyle() {
+        self.headerView?.style = style
     }
     
     func scrollViewOffset(for date: Date) -> CGPoint {
@@ -307,12 +357,12 @@ extension CalendarView {
 
     func indexPathForDate(_ date : Date) -> IndexPath? {
         
-        let distanceFromStartDate = self.calendar.dateComponents([.month, .day], from: self.startOfMonthCache, to: date)
+        let distanceFromStartDate = self.calendar.dateComponents([.month, .day], from: self.firstDayCache, to: date)
         
         guard
             let day   = distanceFromStartDate.day,
             let month = distanceFromStartDate.month,
-            let (firstDayIndex, _) = monthInfoForSection[month] else { return nil }
+            let (firstDayIndex, _) = getCachedSectionInfo(month) else { return nil }
         
         return IndexPath(item: day + firstDayIndex, section: month)
     }
@@ -321,13 +371,13 @@ extension CalendarView {
         
         let month = indexPath.section
         
-        guard let monthInfo = monthInfoForSection[month] else { return nil }
+        guard let monthInfo = getCachedSectionInfo(month) else { return nil }
         
         var components      = DateComponents()
         components.month    = month
         components.day      = indexPath.item - monthInfo.firstDay
         
-        return self.calendar.date(byAdding: components, to: self.startOfMonthCache)
+        return self.calendar.date(byAdding: components, to: self.firstDayCache)
     }
 }
 
@@ -338,7 +388,7 @@ extension CalendarView {
         guard let displayDate = self.displayDate else { return }
         
         var dateComponents = DateComponents()
-        dateComponents.month = offset;
+        dateComponents.month = offset
     
         guard let newDate = self.calendar.date(byAdding: dateComponents, to: displayDate) else { return }
         self.setDisplayDate(newDate, animated: true)
@@ -377,7 +427,8 @@ extension CalendarView {
 			guard (startDateCache..<endDateCache).contains(date) else { return }
 		}
 		
-        self.collectionView.setContentOffset(self.scrollViewOffset(for: date), animated: animated)
+        self.collectionView?.reloadData()
+        self.collectionView?.setContentOffset(self.scrollViewOffset(for: date), animated: animated)
         self.displayDateOnHeader(date)
     }
     

--- a/KDCalendar/ViewController.swift
+++ b/KDCalendar/ViewController.swift
@@ -37,25 +37,26 @@ class ViewController: UIViewController, CalendarViewDataSource, CalendarViewDele
         
         super.viewDidLoad()
         
-        CalendarView.Style.cellShape                = .bevel(8.0)
-        CalendarView.Style.cellColorDefault         = UIColor.clear
-        CalendarView.Style.cellColorToday           = UIColor(red:1.00, green:0.84, blue:0.64, alpha:1.00)
-        CalendarView.Style.cellSelectedBorderColor  = UIColor(red:1.00, green:0.63, blue:0.24, alpha:1.00)
-        CalendarView.Style.cellEventColor           = UIColor(red:1.00, green:0.63, blue:0.24, alpha:1.00)
-        CalendarView.Style.headerTextColor          = UIColor.gray
-        CalendarView.Style.cellTextColorDefault     = UIColor.white
-        CalendarView.Style.cellTextColorToday       = UIColor.orange
-        CalendarView.Style.headerBackgroundColor    = UIColor.white
+        CalendarView.Style.Default.cellShape                = .bevel(8.0)
+        CalendarView.Style.Default.cellColorDefault         = UIColor.clear
+        CalendarView.Style.Default.cellColorToday           = UIColor(red:1.00, green:0.84, blue:0.64, alpha:1.00)
+        CalendarView.Style.Default.cellSelectedBorderColor  = UIColor(red:1.00, green:0.63, blue:0.24, alpha:1.00)
+        CalendarView.Style.Default.cellEventColor           = UIColor(red:1.00, green:0.63, blue:0.24, alpha:1.00)
+        CalendarView.Style.Default.headerTextColor          = UIColor.gray
+        CalendarView.Style.Default.cellTextColorDefault     = UIColor.white
+        CalendarView.Style.Default.cellTextColorToday       = UIColor.orange
+        CalendarView.Style.Default.headerBackgroundColor    = UIColor.white
+        CalendarView.Style.Default.weekdaysBackgroundColor  = UIColor.white
         
-        CalendarView.Style.firstWeekday             = .sunday
+        CalendarView.Style.Default.firstWeekday             = .sunday
         
-        CalendarView.Style.locale                   = Locale(identifier: "en_US")
+        CalendarView.Style.Default.locale                   = Locale(identifier: "en_US")
         
-        CalendarView.Style.timeZone                 = TimeZone(abbreviation: "UTC")!
+        CalendarView.Style.Default.timeZone                 = TimeZone(abbreviation: "UTC")!
         
-        CalendarView.Style.cellFont = UIFont(name: "Helvetica", size: 20.0) ?? UIFont.systemFont(ofSize: 20.0)
-        CalendarView.Style.headerFont = UIFont(name: "Helvetica", size: 20.0) ?? UIFont.systemFont(ofSize: 20.0)
-        CalendarView.Style.subHeaderFont = UIFont(name: "Helvetica", size: 14.0) ?? UIFont.systemFont(ofSize: 14.0)
+        CalendarView.Style.Default.cellFont = UIFont(name: "Helvetica", size: 20.0) ?? UIFont.systemFont(ofSize: 20.0)
+        CalendarView.Style.Default.headerFont = UIFont(name: "Helvetica", size: 20.0) ?? UIFont.systemFont(ofSize: 20.0)
+        CalendarView.Style.Default.weekdaysFont = UIFont(name: "Helvetica", size: 14.0) ?? UIFont.systemFont(ofSize: 14.0)
         
         calendarView.dataSource = self
         calendarView.delegate = self
@@ -95,8 +96,8 @@ class ViewController: UIViewController, CalendarViewDataSource, CalendarViewDele
         
         self.calendarView.setDisplayDate(today)
         
-        self.datePicker.locale = CalendarView.Style.locale
-        self.datePicker.timeZone = CalendarView.Style.timeZone
+        self.datePicker.locale = CalendarView.Style.Default.locale
+        self.datePicker.timeZone = CalendarView.Style.Default.timeZone
         self.datePicker.setDate(today, animated: false)
     }
 


### PR DESCRIPTION
Hi!

I've made it a bit easier to configure.

1. If you have multiple calendars on your screen, you can style each separately
2. Most style settings are now propagating if you set the `style` property even after layout
3. Lazy loading of month info, so a million years range could be setup without any performance impact
4. Better sync of `displayDate`
5. You could now control placement of header components, or deliberately cause month label to be 0.0 height to hide it.
6. RTL support
7. Support for showing adjacent days