### PR TITLE
Fix vertical page jumping

### DIFF
--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -98,8 +98,8 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
             page = Int(floor(offsetX / Float(width)))
         case .vertical:
             let offsetY = ceilf(Float(self.collectionView.contentOffset.y))
-            let width = self.collectionView.bounds.size.width
-            page = Int(floor(offsetY / Float(width)))
+            let height = self.collectionView.bounds.size.height
+            page = Int(floor(offsetY / Float(height)))
         @unknown default:
             fatalError()
         }


### PR DESCRIPTION
When using the calendar in vertical mode, the header could display an incorrect date, I've confirmed that it boils down to dateFromScrollViewPosition using the width rather than the height for page calculation, even in vertical mode.