### PR TITLE
Use standaloneMonthSymbols

### DIFF
--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -123,7 +123,7 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
         formatter.locale = style.locale
         formatter.timeZone = style.calendar.timeZone
         
-        let monthName = formatter.monthSymbols[(month-1) % 12].capitalized // 0 indexed array
+        let monthName = formatter.standaloneMonthSymbols[(month-1) % 12].capitalized // 0 indexed array
         
         let year = self.calendar.component(.year, from: date)
 


### PR DESCRIPTION
We need to use standaloneMonthSymbols instead of monthSymbols in current context for correct localization. These symbols same in english, but different in Russian (for example). 
monthSymbols supposed to be be used in conjunction with day.

monthSymbols - standaloneMonthSymbols
English: May 2019 - May 2019 
Russian: Мая 2019 - Май 2019