### PR TITLE
Add clear all prevent index out of range

### DIFF
--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -34,7 +34,7 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
         if let index = selectedIndexPaths.firstIndex(of: indexPath) {
             
             delegate?.calendar(self, didDeselectDate: date)
-            if enableDeslection {
+            if enableDeselection {
                 // bug: when deselecting the second to last item programmatically, during
                 // didDeselectDate delegation, the index returned is out of the bounds of
                 // the selectedIndexPaths array.  This guard prevents the crash

--- a/KDCalendar/CalendarView/CalendarView+Delegate.swift
+++ b/KDCalendar/CalendarView/CalendarView+Delegate.swift
@@ -35,6 +35,12 @@ extension CalendarView: UICollectionViewDelegateFlowLayout {
             
             delegate?.calendar(self, didDeselectDate: date)
             if enableDeslection {
+                // bug: when deselecting the second to last item programmatically, during
+                // didDeselectDate delegation, the index returned is out of the bounds of
+                // the selectedIndexPaths array.  This guard prevents the crash
+                guard index < selectedIndexPaths.count, index < selectedDates.count else {
+                    return
+                }
                 selectedIndexPaths.remove(at: index)
                 selectedDates.remove(at: index)
             }

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -145,7 +145,7 @@ public class CalendarView: UIView {
     
     public internal(set) var displayDate: Date?
     public var multipleSelectionEnable = true
-    public var enableDeslection = true
+    public var enableDeselection = true
     public var marksWeekends = true
     
     public var delegate: CalendarViewDelegate?

--- a/KDCalendar/CalendarView/CalendarView.swift
+++ b/KDCalendar/CalendarView/CalendarView.swift
@@ -473,6 +473,17 @@ extension CalendarView {
         goToMonthWithOffet(-1)
     }
 
+    /*
+     method: - clearAllSelectedDates
+     function: - clear all selected dates.  Does not call `didDeselectDate` callback
+     */
+    public func clearAllSelectedDates() {
+        selectedIndexPaths.removeAll()
+        selectedDates.removeAll()
+        self.reloadData()
+    }
+
+
     #if KDCALENDAR_EVENT_MANAGER_ENABLED
     
     public func loadEvents(onComplete: ((Error?) -> Void)? = nil) {


### PR DESCRIPTION
Adds a simple`clearAllSelectedDates` method. 
also guards against an index out of range bug